### PR TITLE
Rename & document Dialogue data keys

### DIFF
--- a/addons/Theatre/classes/Stage.gd
+++ b/addons/Theatre/classes/Stage.gd
@@ -98,7 +98,7 @@ func _update_variables_dialogue() -> void:
         )
 
         if is_playing():
-            _dialogue_full_string = _current_dialogue_set[DialogueParser.__LINE]
+            _dialogue_full_string = _current_dialogue_set[DialogueParser.__CONTENT]
             _update_display()
 
             if dialogue_label != null:
@@ -375,7 +375,7 @@ func switch(dialogue : Dialogue) -> void:
 
         if is_playing():
             _current_dialogue_set = current_dialogue._sets[_step]
-            _dialogue_full_string = _current_dialogue_set[DialogueParser.__LINE]
+            _dialogue_full_string = _current_dialogue_set[DialogueParser.__CONTENT]
             _update_display()
             dialogue_label.rerender()
 
@@ -442,7 +442,7 @@ func _progress_forward() -> void:
 
     _step += 1
     _current_dialogue_set = current_dialogue._sets[_step]
-    _dialogue_full_string = _current_dialogue_set[DialogueParser.__LINE]
+    _dialogue_full_string = _current_dialogue_set[DialogueParser.__CONTENT]
 
     _execute_functions()
     _update_display()

--- a/tests/class/DialogueTestUnit.gd
+++ b/tests/class/DialogueTestUnit.gd
@@ -48,11 +48,11 @@ func test(target : Dialogue) -> void:
             var target_data : Dictionary = target_sets[n]
             var ref_data : Dictionary = ref_sets[n]
 
-            if target_data["line"] != ref_data["line"]:
-                log_fail("Inconsistent 'line' at: %d" % n, target_data[DialogueParser.__LINE_NUM])
+            if target_data["content"] != ref_data["content"]:
+                log_fail("Inconsistent 'content' at: %d" % n, target_data[DialogueParser.__LINE_NUM])
 
-            if target_data["line_raw"] != ref_data["line_raw"]:
-                log_fail("Inconsistent 'line_raw' at: %d" % n, target_data[DialogueParser.__LINE_NUM])
+            if target_data["content_raw"] != ref_data["content_raw"]:
+                log_fail("Inconsistent 'content_raw' at: %d" % n, target_data[DialogueParser.__LINE_NUM])
 
             _test_vars(target_data, ref_data)
             _test_tags(target_data, ref_data)

--- a/theatre_demo/preview/preview.gd
+++ b/theatre_demo/preview/preview.gd
@@ -50,5 +50,5 @@ func _dialogue_label_character_drawn() -> void:
 func _stage_progressed_at(_line : int, line_data : Dictionary) -> void:
     progress_bar.value = 0
     progress_bar.max_value = bbcode_regex.sub(
-        line_data["line"], "", true
+        line_data["content"], "", true
     ).length()


### PR DESCRIPTION
Changed the following Dialogue data keys:
- `line` -> `content`
- `line_raw` -> `content_raw`

Add comments for Dialogue data keys' definition.
Also remove some unused empty Array and Dictionary constants.